### PR TITLE
Fix missing erlmc dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -28,7 +28,7 @@
 
         {ddb,           {git, "https://github.com/ErlyORM/ddb.git",                       {tag, "v0.1.7"}}},
         {epgsql,        {git, "https://github.com/epgsql/epgsql.git",                     {tag, "4.2.0"}}},
-        {erlmc,         {git, "https://github.com/layerhq/erlmc.git",                     {ref, "c5280da"}}},
+        {erlmc,         {git, "https://github.com/bipthelin/erlmc.git",                   {ref, "3062f8deb7"}}},
         {mysql,         {git, "https://github.com/ErlyORM/erlang-mysql-driver.git",       {tag, "v0.0.4"}}},
         {poolboy,       {git, "https://github.com/devinus/poolboy.git",                   {tag, "1.5.2"}}},
         {uuid,          {git, "https://github.com/avtobiff/erlang-uuid.git",              {tag, "v0.5.2"}}},


### PR DESCRIPTION
The layerhq/erlmc repository was deleted and after assessing erlmc forks, bipthelin/erlmc seems to be the most current one.